### PR TITLE
Fix photo upload issue

### DIFF
--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -60,6 +60,12 @@ const ConfigPage: React.FC = () => {
     const file = event.target.files?.[0];
     if (!file) return;
 
+    // Check if the uploaded file is an image
+    if (!file.type.startsWith('image/')) {
+      alert('Please upload a valid image file.');
+      return;
+    }
+
     const reader = new FileReader();
     reader.onload = () => {
       const imageDataUrl = reader.result as string;


### PR DESCRIPTION
Add a check to ensure the uploaded file is an image before updating the `posts_images` array in `ConfigPage.tsx`.

* Add a check to ensure the uploaded file is an image before updating the `profilePicture` field.
* Add a check to ensure the uploaded file is an image before updating the `highlights` array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GoulartNogueira/InstagramMockup/pull/2?shareId=93bb3357-94c4-4ab5-b544-9df2455a333a).