### PR TITLE
Fix type of ref prop in PublicationsPage

### DIFF
--- a/src/pages/PublicationsPage.tsx
+++ b/src/pages/PublicationsPage.tsx
@@ -18,7 +18,7 @@ const PublicationsPage: React.FC = () => {
       {profileData.posts_images.map((image, index) => (
         <div
           key={`post-image-${index}`}
-          ref={(el) => (photoRefs.current[index] = el)}
+          ref={(el: HTMLDivElement | null) => (photoRefs.current[index] = el)}
           className="w-full max-w-md mb-4"
         >
           <img


### PR DESCRIPTION
Update the `ref` prop assignment in `src/pages/PublicationsPage.tsx` to fix type error.

* Change the type of the `ref` prop in the `div` element to use `el` as `HTMLDivElement | null`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GoulartNogueira/InstagramMockup/pull/5?shareId=4d9a74da-d354-4c34-807e-cc3c5c90b6f0).